### PR TITLE
Fix !delete command in tips

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -153,7 +153,7 @@ export default class App {
 	 * @returns {void}
 	 */
 	renderCommandTips() {
-		const tips = ["!task", "!edit", "!done", "!remove", "!check", "!help"];
+		const tips = ["!task", "!edit", "!done", "!delete", "!check", "!help"];
 		const commandTipEl = document.querySelector(".command-tips");
 		commandTipEl.classList.remove("hidden");
 		let tipIdx = 0;


### PR DESCRIPTION
I noticed that the overlay mentioned !remove, while that is not actually a command.
Could also add it as an alias if you prefer